### PR TITLE
BE-TSK-13 : 기존 구현 기능 정비

### DIFF
--- a/apps/backend-default-service/src/main/java/kr/co/jineddy/system/api/auth/dto/AuthResponseDto.java
+++ b/apps/backend-default-service/src/main/java/kr/co/jineddy/system/api/auth/dto/AuthResponseDto.java
@@ -2,7 +2,6 @@ package kr.co.jineddy.system.api.auth.dto;
 
 import java.io.Serializable;
 
-import kr.co.jineddy.system.entity.user.SysUserMst;
 import lombok.Builder;
 import lombok.Data;
 
@@ -23,5 +22,5 @@ public class AuthResponseDto implements Serializable {
 	/**
 	 * 사용자 명
 	 */
-	private String useNm;
+	private String userNm;
 }

--- a/apps/backend-default-service/src/main/java/kr/co/jineddy/system/api/cd/dto/CdGroupReqeustDto.java
+++ b/apps/backend-default-service/src/main/java/kr/co/jineddy/system/api/cd/dto/CdGroupReqeustDto.java
@@ -3,12 +3,16 @@ package kr.co.jineddy.system.api.cd.dto;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 시스템 코드 그룹 요청 DTO
  */
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class CdGroupReqeustDto implements Serializable {
 	/**
 	 * 시리얼 버전 ID

--- a/apps/backend-default-service/src/main/java/kr/co/jineddy/system/jwt/JwtTokenProvider.java
+++ b/apps/backend-default-service/src/main/java/kr/co/jineddy/system/jwt/JwtTokenProvider.java
@@ -43,13 +43,13 @@ public class JwtTokenProvider {
 	 */
 	private static final String BEARER_TYPE = "Bearer";
 	/**
-	 * 액세스 토큰 유효 시간 : 30분 / 임시로 하루
+	 * 액세스 토큰 유효 시간 : 1분
 	 */
-	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1440;
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 5;
 	/**
-	 * 리프레시 토큰 유효 시간 : 7일
+	 * 리프레시 토큰 유효 시간 : 12시간
 	 */
-	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 1;
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 12;
 	/**
 	 * 
 	 */

--- a/apps/backend-default-service/src/main/java/kr/co/jineddy/system/service/auth/AuthService.java
+++ b/apps/backend-default-service/src/main/java/kr/co/jineddy/system/service/auth/AuthService.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
@@ -162,6 +163,18 @@ public class AuthService {
 	}
 	
 	/**
+	 * 액세스 토큰 유효성 검증
+	 * @param tokenRequestDto
+	 * @return
+	 */
+	public boolean verify(HttpServletRequest request) {
+		// 액세스 토큰 GET
+		String accessToken = resolveAccessToken(request);
+		
+		return jwtTokenProvider.validateToken(accessToken);
+	}
+	
+	/**
 	 * 토큰 갱신
 	 * @param tokenRequestDto
 	 * @return
@@ -171,6 +184,9 @@ public class AuthService {
 		String accessToken = resolveAccessToken(request);
 		// 리프레시 토큰 GET
 		String refreshToken = resolveRefreshToken(request);
+		
+		log.info("!!!!!!!!!!!!!!!!!!! 토큰갱신 시도 액세스 토큰 : {}", accessToken);
+		log.info("!!!!!!!!!!!!!!!!!!! 토큰갱신 시도 리프레시 토큰 : {}", refreshToken);
 		
 		// Refresh Token 검증
 		if (!jwtTokenProvider.validateToken(refreshToken)) {
@@ -260,6 +276,16 @@ public class AuthService {
 	}
 	
 	/**
+	 * 사용자 정보 조회
+	 * @param userId
+	 * @return
+	 * @throws EntityNotFoundException
+	 */
+	public AuthResponseDto getUserInfo(String userId) throws EntityNotFoundException {
+		return sysUserMstToAuthResponseDto(sysUserMstRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(userId + "에 해당하는 사용자가 없습니다.")));
+	}
+	
+	/**
 	 * 토큰 응답 DTO로 변환
 	 * @param tokenDto
 	 * @return
@@ -288,6 +314,6 @@ public class AuthService {
 	 * @return
 	 */
 	private AuthResponseDto sysUserMstToAuthResponseDto(SysUserMst sysUserMst) {
-		return AuthResponseDto.builder().userId(sysUserMst.getUserId()).useNm(sysUserMst.getUserNm()).build();
+		return AuthResponseDto.builder().userId(sysUserMst.getUserId()).userNm(sysUserMst.getUserNm()).build();
 	}
 }


### PR DESCRIPTION
1.액세스 토큰 및 리프레시 토큰 유효기간 및 쿠키 유효시간 정비
  - 액세스토큰의 유효시간은 5분, 쿠키는 12시간(리프레시와 동일하게)
  - 리프레시 토큰의 유효시간 12시간 쿠키도 12시간
2. 액세스 토큰 유효성 체크 URL 생성
  - 프론트엔드에서 필요해서 추가했었으나 현재 사용하지 않는 상태, 운영 서버 검증 후 불필요 시 삭제 예정